### PR TITLE
Add full 40-pin header for Orange Pi 4(B)

### DIFF
--- a/orangepi/pi4.py
+++ b/orangepi/pi4.py
@@ -39,6 +39,15 @@ BOARD = {
     26: 149,  # GPIO4_C5
     27: 64,   # I2C2_SDA
     28: 65,   # I2C2_SCL
+    29: 121,  # I2S0_RX
+    31: 122,  # I2S0_TX
+    32: 128,  # I2S_CLK
+    33: 120,  # I2S0_SCK
+    35: 123,  # I2S0_SI0
+    36: 127,  # I2S0_SO0
+    37: 124,  # I2S0_SI1
+    38: 125,  # I2S0_SI2
+    40: 126,  # I2S0_SI3
 }
 
 # No reason for BCM mapping, keeping it for compatibility


### PR DESCRIPTION
Hi @drizzle1,

You have previously added the Orange Pi 4 to the OPi.GPIO library. Do you have access to this device?

I found these additional pin mappings in the manual. Is there a reason for not including these? Don't these pins have external interrupts for example?

If you have access to an Orange Pi 4, could you please test if these additional pins work with this library?